### PR TITLE
added keepfileextension option to gonsul

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ type config struct {
 	pollInterval    int
 	Working         chan bool
 	validExtensions []string
+	keepFileExt	    bool	
 	timeout         int
 	version         bool
 }
@@ -65,6 +66,7 @@ type IConfig interface {
 	GetPollInterval() int
 	WorkingChan() chan bool
 	GetValidExtensions() []string
+	KeepFileExt() bool	
 	GetTimeout() int
 	IsShowVersion() bool
 }
@@ -152,6 +154,7 @@ func buildConfig(flags ConfigFlags) (*config, error) {
 		pollInterval:    *flags.PollInterval,
 		Working:         make(chan bool, 1),
 		validExtensions: extensions,
+		keepFileExt:     *flags.KeepFileExt,		
 		timeout:         *flags.Timeout,
 		version:         *flags.Version,
 	}, nil
@@ -235,6 +238,10 @@ func (config *config) WorkingChan() chan bool {
 
 func (config *config) GetValidExtensions() []string {
 	return config.validExtensions
+}
+
+func (config *config) KeepFileExt() bool {
+	return config.keepFileExt
 }
 
 func (config *config) GetTimeout() int {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,7 @@ type config struct {
 	pollInterval    int
 	Working         chan bool
 	validExtensions []string
-	keepFileExt	    bool	
+	keepFileExt     bool
 	timeout         int
 	version         bool
 }
@@ -66,7 +66,7 @@ type IConfig interface {
 	GetPollInterval() int
 	WorkingChan() chan bool
 	GetValidExtensions() []string
-	KeepFileExt() bool	
+	KeepFileExt() bool
 	GetTimeout() int
 	IsShowVersion() bool
 }
@@ -154,7 +154,7 @@ func buildConfig(flags ConfigFlags) (*config, error) {
 		pollInterval:    *flags.PollInterval,
 		Working:         make(chan bool, 1),
 		validExtensions: extensions,
-		keepFileExt:     *flags.KeepFileExt,		
+		keepFileExt:     *flags.KeepFileExt,
 		timeout:         *flags.Timeout,
 		version:         *flags.Version,
 	}, nil

--- a/internal/config/flags_parser.go
+++ b/internal/config/flags_parser.go
@@ -24,6 +24,7 @@ type ConfigFlags struct {
 	AllowDeletes    *bool
 	PollInterval    *int
 	ValidExtensions *string
+	KeepFileExt 	*bool	
 	Timeout         *int
 	Version         *bool
 }
@@ -48,6 +49,7 @@ func parseFlags() ConfigFlags {
 	flags.AllowDeletes = flag.Bool("allow-deletes", false, "Show Gonsul issue deletes? (If not, nothing will be done and a report on conflicting deletes will be shown) (Default false)")
 	flags.PollInterval = flag.Int("poll-interval", 60, "The number of seconds for the repository polling interval")
 	flags.ValidExtensions = flag.String("input-ext", "json,txt,ini", "A comma separated list of file extensions valid as input")
+	flags.KeepFileExt = flag.Bool("keep-FileExt", false, "Do we want to keep file name extensions ? (If not set to true defaults by ommiting the file name extension.) (Default false)")
 	flags.Timeout = flag.Int("timeout", 5, "The number of seconds for the client to wait for a response from Consul")
 	flags.Version = flag.Bool("v", false, "Will show the Gonsul version")
 

--- a/internal/exporter/directory.go
+++ b/internal/exporter/directory.go
@@ -84,8 +84,11 @@ func (e *exporter) cleanFilePath(filePath string) string {
 	entryFilePath := strings.Replace(filePath, replace, "", 1)
 	// Remove any left slash
 	entryFilePath = strings.Replace(entryFilePath, "/", "", 1)
-	// Remove the file extension from the file system path
+	// Set or not the file extension when importing to consul k/v the file
+	if !e.config.KeepFileExt() {
 	entryFilePath = strings.TrimSuffix(entryFilePath, filepath.Ext(entryFilePath))
+	}
+	
 
 	return entryFilePath
 }

--- a/internal/exporter/directory.go
+++ b/internal/exporter/directory.go
@@ -86,9 +86,8 @@ func (e *exporter) cleanFilePath(filePath string) string {
 	entryFilePath = strings.Replace(entryFilePath, "/", "", 1)
 	// Set or not the file extension when importing to consul k/v the file
 	if !e.config.KeepFileExt() {
-	entryFilePath = strings.TrimSuffix(entryFilePath, filepath.Ext(entryFilePath))
+		entryFilePath = strings.TrimSuffix(entryFilePath, filepath.Ext(entryFilePath))
 	}
-	
 
 	return entryFilePath
 }


### PR DESCRIPTION
Hi,

For some cases its useful not to trim the filename extension on the sync process, i have added the option to exclude/include filename extension by adding an extra flag that if set will "skip" trimming the file extension from the entryFilePath var.