### PR TITLE
Allow configuration from environment variables and config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+bin
 vendor
 tests/mocks/*
 !tests/mocks/.gitkeep

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -65,6 +65,14 @@
   revision = "3864e76763d94a6df2f9960b16a20a33da9f9a66"
 
 [[projects]]
+  digest = "1:6221a3a452964b1ff30efdc22209b124d54d04373e5993264d3fa9b13da0659d"
+  name = "github.com/namsral/flag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "71ceffbeb0ba60fccc853971bb3ed4d7d90bfd04"
+  version = "v1.7.4-pre"
+
+[[projects]]
   branch = "master"
   digest = "1:4daa045e1e1f3e23f4b07db6880cdf9f259dab65312dfe244a878e6070faaf77"
   name = "github.com/olekukonko/tablewriter"
@@ -316,6 +324,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/cbroglie/mustache",
+    "github.com/namsral/flag",
     "github.com/olekukonko/tablewriter",
     "github.com/onsi/gomega",
     "github.com/stretchr/testify/mock",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,3 +56,7 @@
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.2"
+
+[[constraint]]
+  name = "github.com/namsral/flag"
+  version = "v1.7.4-pre"

--- a/README.md
+++ b/README.md
@@ -80,8 +80,16 @@ tasks are natively handled by Gonsul, as long as filesystem and network permissi
 
 
 ## Available Flags
-Below are all available command line flags for starting **Gonsul**
+Below are all available command line flags for starting **Gonsul**. Flags may be specified on the command line, using
+environment variables (flag prefixed with "GONSUL_", converted to upper case, and "-" changed to "_", e.g.
+`GONSUL_REPO_URL`), or using a configuration file (`--config=`). The order of precedence for specifying flags is:
+1. Command line options
+2. Environment variables
+3. Configuration file
+4. Default values
+
 ```bash
+--config=
 --strategy=
 --repo-url=
 --repo-ssh-key=
@@ -101,7 +109,17 @@ Below are all available command line flags for starting **Gonsul**
 --input-ext=
 --keep-ext=
 ```
-Below is the full description for each individual command line flag
+Below is the full description for each individual command line flag.
+
+
+### `--config`
+> `require:` **no**
+> `example:` **`--config=gonsul.conf`**
+
+This specifies a file with configuration settings for the options described below. File syntax:
+- Empty lines and lines beginning with a "#" character are ignored.
+- Flags and values can be separated with whitespace or the "=" character (`strategy ONCE` or `strategy=DRYRUN`).
+- Booleans can be empty (true) or set with "1/0", "t/f", "T/F", "true/false", "TRUE/FALSE", or "True/False".
 
 
 ### `--strategy` 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,11 +5,11 @@ import (
 
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
+	"github.com/namsral/flag"
 )
 
 const StrategyDry = "DRYRUN"

--- a/internal/config/flags_parser.go
+++ b/internal/config/flags_parser.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	"flag"
 	"fmt"
+	"os"
 	"github.com/miniclip/gonsul/internal/util"
+	"github.com/namsral/flag"
 )
 
 type ConfigFlags struct {
@@ -32,6 +33,10 @@ type ConfigFlags struct {
 
 func parseFlags() ConfigFlags {
 	flags := ConfigFlags{}
+
+	flag.CommandLine = flag.NewFlagSetWithEnvPrefix(os.Args[0], "GONSUL", flag.ExitOnError)
+
+	flag.String(flag.DefaultConfigFlagname, "", "The path to a configuration file")
 
 	flags.LogLevel = flag.String("log-level", util.LogErr, fmt.Sprintf("The desired log level (%s, %s, %s)", util.LogErr, util.LogInfo, util.LogDebug))
 	flags.Strategy = flag.String("strategy", StrategyOnce, fmt.Sprintf("The Gonsul operation mode (%s, %s, %s, %s)", StrategyDry, StrategyOnce, StrategyPoll, StrategyHook))


### PR DESCRIPTION
Using `github.com/namsral/flag` will allow configuration via environment variables (`GONSUL_<FLAG_NAME>`) and config file (`--config`). These options help with 12-factor and/or hiding sensitive data from command line arguments.