### PR TITLE
Fix insecure logging of HTTP username and password for Git repo URL

### DIFF
--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -30,10 +30,10 @@ func (e *exporter) Start() map[string]string {
 
 	// Should we clone the repo, or is it already done via 3rd party
 	if e.config.IsCloning() {
-		e.logger.PrintInfo("EXPORTER: GIT cloning from: " + e.config.GetRepoURL())
+		e.logger.PrintInfo("EXPORTER: Git cloning from configured remote repository")
 		e.downloadRepo()
 	} else {
-		e.logger.PrintInfo("EXPORTER: Skipping GIT clone, using local path: " + e.config.GetRepoRootDir())
+		e.logger.PrintInfo("EXPORTER: Skipping Git clone, using local path: " + e.config.GetRepoRootDir())
 	}
 
 	// Set the path where Gonsul should start traversing files to add to Consul


### PR DESCRIPTION
Current implementation logs HTTP Basic Auth username and password from Git repo HTTP URLs to INFO log. This commit removes the repo URL from the affected log statement.

* Removed GetRepoURL() function call from exporter cloning step.
* Pedantic re-casing of "GIT" to "Git" 😅 

Example:
```
[INFO]  [Jun  3 11:37:43.875] EXPORTER: GIT cloning from: https://alice.bob:hunter2@github.com/companyrepo/consul-kv
```