### PR TITLE
Remove `make test` deprecation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GOPATH?=${HOME}/go
 mocks:
 	@echo "=== Generating mocks ==="
 	rm -rf ./tests/mocks/*.go
-	go get github.com/vektra/mockery/v2/.../
+	go install github.com/vektra/mockery/v2/.../
 	CGO_ENABLED=0 $(GOPATH)/bin/mockery --all --output ./tests/mocks --dir ./app/
 	CGO_ENABLED=0 $(GOPATH)/bin/mockery --all --output ./tests/mocks --dir ./internal/
 	@echo "=== Done ==="


### PR DESCRIPTION
This may address #37.

At least locally, I'm getting no deprecation warnings.