### PR TITLE
Adding flag to skip insecure Consul TLS certificate

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/namsral/flag"
 	"io/ioutil"
 	"os"
 	"strings"
-	"github.com/namsral/flag"
 )
 
 const StrategyDry = "DRYRUN"
@@ -18,30 +18,31 @@ const StrategyPoll = "POLL"
 const StrategyHook = "HOOK"
 
 type config struct {
-	shouldClone     bool
-	logLevel        int
-	strategy        string
-	repoUrl         string
-	repoSSHKey      string
-	repoSSHUser     string
-	repoBranch      string
-	repoRemoteName  string
-	repoBasePath    string
-	repoRootDir     string
-	consulURL       string
-	consulACL       string
-	consulBasePath  string
-	expandJSON      bool
-	expandYAML      bool
-	doSecrets       bool
-	secretsMap      map[string]string
-	allowDeletes    string
-	pollInterval    int
-	Working         chan bool
-	validExtensions []string
-	keepFileExt     bool
-	timeout         int
-	version         bool
+	shouldClone              bool
+	logLevel                 int
+	strategy                 string
+	repoUrl                  string
+	repoSSHKey               string
+	repoSSHUser              string
+	repoBranch               string
+	repoRemoteName           string
+	repoBasePath             string
+	repoRootDir              string
+	consulURL                string
+	consulInsecureSkipVerify bool
+	consulACL                string
+	consulBasePath           string
+	expandJSON               bool
+	expandYAML               bool
+	doSecrets                bool
+	secretsMap               map[string]string
+	allowDeletes             string
+	pollInterval             int
+	Working                  chan bool
+	validExtensions          []string
+	keepFileExt              bool
+	timeout                  int
+	version                  bool
 }
 
 // IConfig is our config interface, implemented by our config struct above. It allows
@@ -58,6 +59,7 @@ type IConfig interface {
 	GetRepoBasePath() string
 	GetRepoRootDir() string
 	GetConsulURL() string
+	GetConsulInsecureSkipVerify() bool
 	GetConsulACL() string
 	GetConsulBasePath() string
 	ShouldExpandJSON() bool
@@ -142,30 +144,31 @@ func buildConfig(flags ConfigFlags) (*config, error) {
 	}
 
 	return &config{
-		shouldClone:     clone,
-		logLevel:        errorLevel,
-		strategy:        strategy,
-		repoUrl:         *flags.RepoURL,
-		repoSSHKey:      *flags.RepoSSHKey,
-		repoSSHUser:     *flags.RepoSSHUser,
-		repoBranch:      *flags.RepoBranch,
-		repoRemoteName:  *flags.RepoRemoteName,
-		repoBasePath:    *flags.RepoBasePath,
-		repoRootDir:     *flags.RepoRootDir,
-		consulURL:       *flags.ConsulURL,
-		consulACL:       *flags.ConsulACL,
-		consulBasePath:  *flags.ConsulBasePath,
-		expandJSON:      *flags.ExpandJSON,
-		expandYAML:      *flags.ExpandYAML,
-		doSecrets:       doSecrets,
-		secretsMap:      secrets,
-		allowDeletes:    *flags.AllowDeletes,
-		pollInterval:    *flags.PollInterval,
-		Working:         make(chan bool, 1),
-		validExtensions: extensions,
-		keepFileExt:     *flags.KeepFileExt,
-		timeout:         *flags.Timeout,
-		version:         *flags.Version,
+		shouldClone:              clone,
+		logLevel:                 errorLevel,
+		strategy:                 strategy,
+		repoUrl:                  *flags.RepoURL,
+		repoSSHKey:               *flags.RepoSSHKey,
+		repoSSHUser:              *flags.RepoSSHUser,
+		repoBranch:               *flags.RepoBranch,
+		repoRemoteName:           *flags.RepoRemoteName,
+		repoBasePath:             *flags.RepoBasePath,
+		repoRootDir:              *flags.RepoRootDir,
+		consulURL:                *flags.ConsulURL,
+		consulInsecureSkipVerify: *flags.ConsulInsecureSkipVerify,
+		consulACL:                *flags.ConsulACL,
+		consulBasePath:           *flags.ConsulBasePath,
+		expandJSON:               *flags.ExpandJSON,
+		expandYAML:               *flags.ExpandYAML,
+		doSecrets:                doSecrets,
+		secretsMap:               secrets,
+		allowDeletes:             *flags.AllowDeletes,
+		pollInterval:             *flags.PollInterval,
+		Working:                  make(chan bool, 1),
+		validExtensions:          extensions,
+		keepFileExt:              *flags.KeepFileExt,
+		timeout:                  *flags.Timeout,
+		version:                  *flags.Version,
 	}, nil
 }
 
@@ -215,6 +218,10 @@ func (config *config) GetConsulURL() string {
 
 func (config *config) GetConsulACL() string {
 	return config.consulACL
+}
+
+func (config *config) GetConsulInsecureSkipVerify() bool {
+	return config.consulInsecureSkipVerify
 }
 
 func (config *config) GetConsulBasePath() string {

--- a/internal/config/flags_parser.go
+++ b/internal/config/flags_parser.go
@@ -2,33 +2,34 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"github.com/miniclip/gonsul/internal/util"
 	"github.com/namsral/flag"
+	"os"
 )
 
 type ConfigFlags struct {
-	LogLevel        *string
-	Strategy        *string
-	RepoURL         *string
-	RepoSSHKey      *string
-	RepoSSHUser     *string
-	RepoBranch      *string
-	RepoRemoteName  *string
-	RepoBasePath    *string
-	RepoRootDir     *string
-	ConsulURL       *string
-	ConsulACL       *string
-	ConsulBasePath  *string
-	ExpandJSON      *bool
-	ExpandYAML      *bool
-	SecretsFile     *string
-	AllowDeletes    *string
-	PollInterval    *int
-	ValidExtensions *string
-	KeepFileExt     *bool
-	Timeout         *int
-	Version         *bool
+	LogLevel                 *string
+	Strategy                 *string
+	RepoURL                  *string
+	RepoSSHKey               *string
+	RepoSSHUser              *string
+	RepoBranch               *string
+	RepoRemoteName           *string
+	RepoBasePath             *string
+	RepoRootDir              *string
+	ConsulURL                *string
+	ConsulInsecureSkipVerify *bool
+	ConsulACL                *string
+	ConsulBasePath           *string
+	ExpandJSON               *bool
+	ExpandYAML               *bool
+	SecretsFile              *string
+	AllowDeletes             *string
+	PollInterval             *int
+	ValidExtensions          *string
+	KeepFileExt              *bool
+	Timeout                  *int
+	Version                  *bool
 }
 
 func parseFlags() ConfigFlags {
@@ -48,6 +49,7 @@ func parseFlags() ConfigFlags {
 	flags.RepoBasePath = flag.String("repo-base-path", "/", "The base directory to look from inside the repo")
 	flags.RepoRootDir = flag.String("repo-root", "/tmp/gonsul/repo", "The path where the repo will be downloaded to")
 	flags.ConsulURL = flag.String("consul-url", "", "(REQUIRED) The Consul URL REST API endpoint (Full URL with scheme)")
+	flags.ConsulInsecureSkipVerify = flag.Bool("consul-insecure-skip-verify", false, "Ignore insecure Consul TLS certificate")
 	flags.ConsulACL = flag.String("consul-acl", "", "The Consul ACL to use (Must have write on the KV following --consul-base path)")
 	flags.ConsulBasePath = flag.String("consul-base-path", "", "The base KV path will be prefixed to dir path")
 	flags.ExpandJSON = flag.Bool("expand-json", false, "Expand and parse JSON files as full paths? (Default false)")


### PR DESCRIPTION
This changes adds a `consul-insecure-skip-verify` flag so 'insecure' Consul certificate verification is skipped.