### PR TITLE
fix numbers (ints) not getting set in consul

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,14 +26,12 @@ require (
 	github.com/onsi/ginkgo v1.16.1 // indirect
 	github.com/onsi/gomega v1.10.1
 	github.com/pelletier/go-buffruneio v0.2.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/tsdb v0.7.1 // indirect
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/soheilhy/cmux v0.1.4 // indirect
 	github.com/src-d/gcfg v1.3.0 // indirect
-	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	github.com/ugorji/go v1.1.4 // indirect

--- a/internal/exporter/expander.go
+++ b/internal/exporter/expander.go
@@ -27,6 +27,10 @@ func (e *exporter) traverseMap(path string, arbitraryJSON map[string]interface{}
 			piece := e.createPiece(newPath, fmt.Sprint(value.(float64)))
 			localData[piece.KVPath] = piece.Value
 
+		case int:
+			piece := e.createPiece(newPath, fmt.Sprint(value.(int)))
+			localData[piece.KVPath] = piece.Value
+
 		case []interface{}:
 			// We have an array - ohoh
 			// Array inside consul are... well are not! Insert as string for now


### PR DESCRIPTION
I ran into this issue https://github.com/miniclip/gonsul/issues/35 and need this to work so I've opened a pull request. This fixes being able to have yaml/json files with numbers not needing quotes around them in order to be parsed for consul input.